### PR TITLE
configuration parameters affecting behavior candidates and guards

### DIFF
--- a/bench_horn/s_split_57.smt2
+++ b/bench_horn/s_split_57.smt2
@@ -1,0 +1,27 @@
+(declare-rel inv (Int Int Int Int))
+(declare-var x0 Int)
+(declare-var x1 Int)
+(declare-var y0 Int)
+(declare-var y1 Int)
+(declare-var z0 Int)
+(declare-var z1 Int)
+(declare-var w0 Int)
+(declare-var w1 Int)
+
+(declare-rel fail ())
+
+(rule (=> (and (= x0 0) (= y0 1000) (= z0 2000) (= w0 3000))
+    (inv x0 y0 z0 w0)))
+
+(rule (=> (and
+        (inv x0 y0 z0 w0)
+        (= x1 (+ 1 x0))
+        (= y1 (ite (>= x0 1000) (+ y0 1) y0))
+        (= z1 (ite (>= y0 2000) (+ z0 1) z0))
+        (= w1 (ite (>= z0 3000) (+ w0 1) w0)))
+    (inv x1 y1 z1 w1)))
+
+(rule (=> (and (inv x0 y0 z0 w0) (>= z0 3000)
+    (not (= x0 w0))) fail))
+
+(query fail)

--- a/bench_horn/s_split_58.smt2
+++ b/bench_horn/s_split_58.smt2
@@ -1,0 +1,22 @@
+(declare-rel inv (Int Int Int))
+(declare-var x0 Int)
+(declare-var x1 Int)
+(declare-var y0 Int)
+(declare-var z0 Int)
+(declare-var z1 Int)
+
+(declare-rel fail ())
+
+(rule (=> (and (= x0 0) (= z0 0))
+    (inv x0 y0 z0)))
+
+(rule (=> (and
+        (inv x0 y0 z0)
+        (= x1 (+ 1 x0))
+        (= z1 (ite (= y0 (div x0 1000)) (+ z0 1) z0)))
+    (inv x1 y0 z1)))
+
+(rule (=> (and (inv x0 y0 z0) (> x0 (* 1000 (+ 1 y0))) (>= y0 0)
+    (not (= z0 1000))) fail))
+
+(query fail)

--- a/bench_horn/tg.smt2
+++ b/bench_horn/tg.smt2
@@ -1,0 +1,29 @@
+(declare-rel inv (Int Int Int))
+(declare-var x0 Int)
+(declare-var x1 Int)
+(declare-var x2 Int)
+(declare-var y0 Int)
+(declare-var y1 Int)
+(declare-var y2 Int)
+(declare-var z0 Int)
+(declare-var z1 Int)
+(declare-var z2 Int)
+
+(declare-rel fail ())
+
+(rule (=> (= x0 0) (inv x0 y0 z0)))
+
+(rule (=> (and (inv x0 y0 z0)
+    (ite (>= x0 5)             (and (= x1 x0)        (= y1 (+ y0 1))  (= z1 z0))
+                               (and (= x1 (+ x0 1))  (= y1 y0)        (= z1 z0)))
+    (ite (<= y1 5)             (and (= x2 x1)        (= y2 y1)        (= z2 (+ z1 1)))
+             (ite (> x1 y1)    (and (= x2 x1)        (= y2 (+ y1 1))  (= z2 z1))
+                               (and (= x2  0)        (= y2 y1)        (= z2 z1)))))
+    (inv x2 y2 z2)))
+
+(rule (=> (and (inv x0 y0 z0)
+    (ite (>= x0 5)             (and (= x1 x0)       (= y1 (+ y0 1))  (= z1 z0))
+                               (and (= x1 (+ x0 1)) (= y1 y0)        (= z1 z0)))
+    (> y1 5) (> x1 y1)) fail))
+
+(query fail)

--- a/bench_horn_multiple/s_seeds_01_m.smt2
+++ b/bench_horn_multiple/s_seeds_01_m.smt2
@@ -1,0 +1,50 @@
+(declare-rel inv (Int Int))
+(declare-rel inv1 (Int Int))
+(declare-rel inv2 (Int Int))
+(declare-var x Int)
+(declare-var x1 Int)
+(declare-var y Int)
+(declare-var y1 Int)
+
+(declare-rel fail ())
+
+(rule (=> (and (= x 0) (= y 0)) (inv x y)))
+
+(rule (=> 
+    (and 
+        (inv x y)
+        (= x1 (+ x 1))
+        (= y1 (- y 1))
+    )
+    (inv x1 y1)
+  )
+)
+
+(rule (=> (and (inv x y) (> x 0)) (inv1 x y)))
+
+(rule (=>
+    (and
+        (inv1 x y)
+        (= x1 (- x 1))
+        (= y1 (+ y 1))
+    )
+    (inv1 x1 y1)
+  )
+)
+
+(rule (=> (and (inv1 x y) (= y 0)) (inv2 x y)))
+
+(rule (=>
+    (and
+        (inv2 x y)
+        (= x1 (+ x 1))
+        (= y1 (+ y 1))
+    )
+    (inv2 x1 y1)
+  )
+)
+
+(rule (=> (and (inv2 x y) (not (= x y))) fail))
+
+(query fail)
+

--- a/include/ae/SMTUtils.hpp
+++ b/include/ae/SMTUtils.hpp
@@ -218,6 +218,21 @@ namespace ufo
     }
 
     /**
+     * Check if phi has one model
+     */
+    boost::tribool hasOneModel(Expr phi) {
+      if (isFalse(phi)) return false;
+
+      getModelPtr();
+      if (m == NULL) return indeterminate;
+
+      ExprSet assumptions;
+      assumptions.insert(mk<NEG>(getModel()));
+
+      return !isSat(assumptions, false);
+    }
+
+    /**
      * ITE-simplifier (prt 2)
      */
     Expr simplifyITE(Expr ex, Expr upLevelCond)
@@ -351,6 +366,17 @@ namespace ufo
         removeRedundantConjuncts(conjs);
         return conjoin(conjs, efac);
       }
+    }
+
+    void removeRedundantConjunctsVec(ExprVector& exps)
+    {
+      ExprVector expsn;
+      for (auto e : exps)
+      {
+        e = removeRedundantConjuncts(e);
+        if (!isOpX<TRUE>(e)) expsn.push_back(e);
+      }
+      exps = expsn;
     }
 
     /**

--- a/include/ufo/Expr.hpp
+++ b/include/ufo/Expr.hpp
@@ -3590,6 +3590,14 @@ namespace expr
         sz++;
       }
 
+      bool has_edge (int f, Expr e)
+      {
+        for (auto c : tree_edgs[f])
+          if (tree_cont[c] == e)
+            return true;
+        return false;
+      }
+
       void deleteIntermPaths()
       {
         for (auto it = to_del_paths.rbegin(); it != to_del_paths.rend(); ++it)


### PR DESCRIPTION
`--data <NUM>` enables generating `NUM` data matrices, each for separate candidate generation
`--re` enables recycling (weaker versions of) data candidates in the `--disj` mode
`--prune` aggressively filters the generated candidates
`--stren-mbp` redesigned to use abduction w.r.t. initial states
additionally, the MBP computation is improved/optimized, and array candidates are more accurate now